### PR TITLE
Remove device_id index from device_statistics

### DIFF
--- a/db/migrate/20160704101157_remove_device_id_index_on_device_statistics.rb
+++ b/db/migrate/20160704101157_remove_device_id_index_on_device_statistics.rb
@@ -1,0 +1,5 @@
+class RemoveDeviceIdIndexOnDeviceStatistics < ActiveRecord::Migration
+  def change
+    remove_index :device_statistics, :device_id
+  end
+end


### PR DESCRIPTION
It turns out that the MySQL query was ignoring the index with device_id and
label because of the index with just the device_id