### PR TITLE
Changed production level log to warn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
The logs on production currently include all of the Info level logs - this means it shows what pages are being loaded, assets, etc. 

This is too much for a production environment, so I've changed the default level to 'warn' to reduce the log 'noise'